### PR TITLE
Volume subpath not taken into account can result in transforms returning 404.

### DIFF
--- a/src/ImageTransformer.php
+++ b/src/ImageTransformer.php
@@ -43,7 +43,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
     protected function assetUrl(Collection $params)
     {
         $basePath = rtrim(
-            $this->asset->fs->getRootUrl(),
+            $this->asset->fs->getRootUrl() . $this->asset->getVolume()->getSubpath(),
             '/'
         );
 


### PR DESCRIPTION
When a Volume uses a subpath, the final transform URL doesn't route to the asset correctly.

**Before this change:**

A remote volume on R2, with a subpath `media` will store assets in `r2://my-bucket/media`, but the transform will try to be served from:

```
https://exampledomain/cdn-cgi/image/width=60,height=40,quality=82,format=auto,fit=cover/beach.jpg
```

This is a 404.

**After:**

The transform will be served from 

```
https://exampledomain/cdn-cgi/image/width=60,height=40,quality=82,format=auto,fit=cover/media/beach.jpg
```

Which returns the image.

Volumes without a subpath will return an empty string, so shouldn't change the existing behaviour.